### PR TITLE
Fix #25

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,6 +100,12 @@ define(function (require, exports, module) {
         return; 
       }
       
+      if (mFile._contents === null || oFile._contents === null) {
+        notifier.error('To compare files, please open the folder containing these files in Brackets using the pane on the left.');
+        Logger.error('To compare files, please open the folder containing these files in Brackets using the pane on the left.');
+        return; 
+      }
+      
       if (getExtension(mFile._name) !== getExtension(oFile._name)) {
         notifier.error('Cannot compare files of different types. Please select files of the same type.');
         Logger.error('Cannot compare files of different types. Please select files of the same type.');


### PR DESCRIPTION
Brackets doesn't provide file contents (._contents property) if the files are not in a watched directory. This fixes #25 by providing an instruction to the user instead of silently failing to show the comparison.